### PR TITLE
Adds support for running process with setuid, setgid, and working directory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.1.1.0
+
+* Adds support for setuid and setguid when running command
+* Adds support for setting current directory when running command
+
 ## 0.1.0.1
 
 * Turn off all RTS options

--- a/README.md
+++ b/README.md
@@ -50,7 +50,3 @@ are:
    ```
    docker run --rm --entrypoint /usr/bin/env fpco/pid1 /sbin/pid1 ps
    ```
-   
-If running pid1 standalone outside of docker, pid1 supports similar run command
-line options for changing the user, group, and working directory of the
-executable.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ repo](https://github.com/snoyberg/docker-testing#readme).
 
 ### Usage
 
+> pid1 [-e|--env LIST][-u|--user USER] [-g|--group GROUP] [-w|--workdir DIR] COMMAND [ARG1 ARG2 ... ARGN] 
+
+Where:
+* `-e`, `--env` `LIST` - Override environment variables. Comma separated
+  key=value pairs of environment variables to override in the existing
+  environment.
+* `-u`, `--user` `USER` - The username the process will setuid before executing
+  COMMAND
+* `-g`, `--group` `GROUP` - The group name the process will setgid before
+  executing COMMAND
+* `-w`, `--workdir` `DIR` - chdir to `DIR` before executing COMMAND
+
 The recommended use case for this executable is to embed it in a Docker image.
 Assuming you've placed it at `/sbin/pid1`, the two commonly recommended usages
 are:
@@ -38,3 +50,7 @@ are:
    ```
    docker run --rm --entrypoint /usr/bin/env fpco/pid1 /sbin/pid1 ps
    ```
+   
+If running pid1 standalone outside of docker, pid1 supports similar run command
+line options for changing the user, group, and working directory of the
+executable.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,19 +1,45 @@
-module Main where
-
+module Main (main) where
 -- | This is a valid PID 1 process in Haskell, intended as a Docker
 -- entrypoint. It will handle reaping orphans and handling TERM and
 -- INT signals.
+
+import Data.List (foldl')
+import Data.Maybe (fromMaybe)
 import System.Process.PID1
 import System.Environment
+import System.Console.GetOpt
+import System.IO (stderr, hPutStr)
+import System.Exit (exitFailure)
+
+-- | `GetOpt` command line options
+options :: [(String, String)] -> [OptDescr (RunOptions -> RunOptions)]
+options defaultEnv =
+  [ Option ['e'] ["env"] (ReqArg (\opt flags -> flags { runEnv = optEnvList (runEnv flags) opt }) "LIST") "set environment variables from list of comma separated name=value pairs. Can be specified multiple times"
+  , Option ['u'] ["user"] (ReqArg (\opt flags -> flags { runUser = Just opt }) "USER") "run command as user"
+  , Option ['g'] ["group"] (ReqArg (\opt flags -> flags { runGroup = Just opt}) "GROUP") "run command as group"
+  , Option ['w'] ["workdir"] (ReqArg (\opt flags -> flags { runWorkDir = Just opt}) "DIR") "command working directory"]
+  where optEnv env' kv =
+          let kvp = fmap (drop 1) $ span (/= '=') kv in
+            kvp:filter ((fst kvp /=) . fst) env'
+        split [] = []
+        split s = case fmap (drop 1) $ span (/= ',') s of
+          ("", xs') -> split xs'
+          (x, xs') -> x:split xs'
+        optEnvList env' s = Just
+          $ foldl' optEnv (fromMaybe defaultEnv env')
+          $ split s
 
 main :: IO ()
 main = do
     -- Figure out the actual thing to run and spawn it off.
     args0 <- getArgs
-
-    (cmd, args) <-
-        case args0 of
-            [] -> error "No arguments provided"
-            cmd:args -> return (cmd, args)
-
-    run cmd args Nothing
+    defaultEnv <- getEnvironment
+    progName <- getProgName
+    let opts = options defaultEnv
+    case getOpt RequireOrder opts args0 of
+      (o, (cmd:args), []) -> let runOpts = foldl (flip id) defaultRunOptions o in
+        runWithOptions runOpts cmd args
+      _ -> do
+        let usage = "Usage: " ++ progName ++ " [OPTION...] command [args...]"
+        hPutStr stderr (usageInfo usage opts)
+        exitFailure

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,10 +14,10 @@ import System.Exit (exitFailure)
 -- | `GetOpt` command line options
 options :: [(String, String)] -> [OptDescr (RunOptions -> RunOptions)]
 options defaultEnv =
-  [ Option ['e'] ["env"] (ReqArg (\opt flags -> flags { runEnv = optEnvList (runEnv flags) opt }) "LIST") "set environment variables from list of comma separated name=value pairs. Can be specified multiple times"
-  , Option ['u'] ["user"] (ReqArg (\opt flags -> flags { runUser = Just opt }) "USER") "run command as user"
-  , Option ['g'] ["group"] (ReqArg (\opt flags -> flags { runGroup = Just opt}) "GROUP") "run command as group"
-  , Option ['w'] ["workdir"] (ReqArg (\opt flags -> flags { runWorkDir = Just opt}) "DIR") "command working directory"]
+  [ Option ['e'] ["env"] (ReqArg (\opt opts -> setRunEnv (optEnvList (getRunEnv opts) opt) opts) "LIST") "set environment variables from list of comma separated name=value pairs. Can be specified multiple times"
+  , Option ['u'] ["user"] (ReqArg setRunUser "USER") "run command as user"
+  , Option ['g'] ["group"] (ReqArg setRunGroup "GROUP") "run command as group"
+  , Option ['w'] ["workdir"] (ReqArg setRunWorkDir "DIR") "command working directory"]
   where optEnv env' kv =
           let kvp = fmap (drop 1) $ span (/= '=') kv in
             kvp:filter ((fst kvp /=) . fst) env'
@@ -25,9 +25,7 @@ options defaultEnv =
         split s = case fmap (drop 1) $ span (/= ',') s of
           ("", xs') -> split xs'
           (x, xs') -> x:split xs'
-        optEnvList env' s = Just
-          $ foldl' optEnv (fromMaybe defaultEnv env')
-          $ split s
+        optEnvList env' s = foldl' optEnv (fromMaybe defaultEnv env') $ split s
 
 main :: IO ()
 main = do

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -12,7 +12,7 @@ docker run --rm \
     -v $(pwd)/build-docker:/host-bin \
     -v $SDIST:/sdist.tar.gz \
     -v $(pwd)/build-home:/home/build \
-    fpco/docker-static-haskell:8.0.1 \
+    fpco/docker-static-haskell:8.0.2 \
     /bin/bash -c \
     'chown $(id -u) $HOME && rm -rf $HOME/pid1-* && tar zxfv /sdist.tar.gz && cd pid1-* && stack install --system-ghc --test --local-bin-path /host-bin --ghc-options "-optl-static -fPIC -optc-Os" && upx --best --ultra-brute /host-bin/pid1'
 
@@ -31,6 +31,6 @@ docker build --tag fpco/pid1:16.04 build-docker
 docker run --rm fpco/pid1:16.04 ps
 
 # Push
-docker tag -f fpco/pid1:16.04 fpco/pid1:latest
+docker tag fpco/pid1:16.04 fpco/pid1:latest
 docker push fpco/pid1:16.04
 docker push fpco/pid1:latest

--- a/pid1.cabal
+++ b/pid1.cabal
@@ -1,5 +1,5 @@
 name:                pid1
-version:             0.1.0.1
+version:             0.1.1.0
 synopsis:            Do signal handling and orphan reaping for Unix PID1 init processes
 description:         Please see README.md or view Haddocks at <https://www.stackage.org/package/pid1>
 homepage:            https://github.com/fpco/pid1#readme
@@ -19,6 +19,7 @@ library
   build-depends:       base >= 4 && < 5
                      , process >= 1.2
                      , unix
+                     , directory
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/src/System/Process/PID1.hs
+++ b/src/System/Process/PID1.hs
@@ -2,12 +2,16 @@
 module System.Process.PID1
     ( RunOptions
     , defaultRunOptions
+    , getRunEnv
+    , getRunGroup
+    , getRunUser
+    , getRunWorkDir
     , run
-    , runEnv
-    , runUser
-    , runGroup
     , runWithOptions
-    , runWorkDir
+    , setRunEnv
+    , setRunGroup
+    , setRunUser
+    , setRunWorkDir
     ) where
 
 import           Control.Concurrent       (forkIO, newEmptyMVar, takeMVar,
@@ -46,8 +50,58 @@ data RunOptions = RunOptions
   } deriving Show
 
 -- | return default `RunOptions`
+--
+-- @since 0.1.1.0
 defaultRunOptions :: RunOptions
 defaultRunOptions = RunOptions { runEnv = Nothing, runUser = Nothing, runGroup = Nothing, runWorkDir = Nothing }
+
+-- | Get environment variable overrides for the given `RunOptions`
+--
+-- @since 0.1.1.0
+getRunEnv :: RunOptions -> Maybe [(String, String)]
+getRunEnv = runEnv
+
+-- | Set environment variable overrides for the given `RunOptions`
+--
+-- @since 0.1.1.0
+setRunEnv :: [(String, String)] -> RunOptions -> RunOptions
+setRunEnv env' opts = opts { runEnv = Just env' }
+
+-- | Get the process 'setUserID' user for the given `RunOptions`
+--
+-- @since 0.1.1.0
+getRunUser :: RunOptions -> Maybe String
+getRunUser = runUser
+
+-- | Set the process 'setUserID' user for the given `RunOptions`
+--
+-- @since 0.1.1.0
+setRunUser :: String -> RunOptions -> RunOptions
+setRunUser user opts = opts { runUser = Just user }
+
+-- | Get the process 'setGroupID' group for the given `RunOptions`
+--
+-- @since 0.1.1.0
+getRunGroup :: RunOptions -> Maybe String
+getRunGroup = runGroup
+
+-- | Set the process 'setGroupID' group for the given `RunOptions`
+--
+-- @since 0.1.1.0
+setRunGroup :: String -> RunOptions -> RunOptions
+setRunGroup group opts = opts { runGroup = Just group }
+
+-- | Get the process current directory for the given `RunOptions`
+--
+-- @since 0.1.1.0
+getRunWorkDir :: RunOptions -> Maybe FilePath
+getRunWorkDir = runWorkDir
+
+-- | Set the process current directory for the given `RunOptions`
+--
+-- @since 0.1.1.0
+setRunWorkDir :: FilePath -> RunOptions -> RunOptions
+setRunWorkDir dir opts = opts { runWorkDir = Just dir }
 
 -- | Run the given command with specified arguments, with optional environment
 -- variable override (default is to use the current process's environment).

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.1
+resolver: lts-8.21
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
I found the pid1 utility useful outside of pure docker entrypoint by adding command line support for setting user (`-u USER`), group (`-g GROUP`), working directory (`-w DIR`), and finally environment overrides (`-e key=value`).