### PR TITLE
Adds support for `-t` child process kill timeout option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 * Removes support for ',' separated list of environment variables
   for `-e` command line option
+* Adds support for setting child processes wait timeout on SIGTERM or SIGINT
 
 ## 0.1.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.1.2.0
+
+* Removes support for ',' separated list of environment variables
+  for `-e` command line option
+
 ## 0.1.1.0
 
 * Adds support for setuid and setguid when running command

--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ repo](https://github.com/snoyberg/docker-testing#readme).
 
 ### Usage
 
-> pid1 [-e|--env LIST][-u|--user USER] [-g|--group GROUP] [-w|--workdir DIR] COMMAND [ARG1 ARG2 ... ARGN] 
+> pid1 [-e|--env ENV] [-u|--user USER] [-g|--group GROUP] [-w|--workdir DIR] COMMAND [ARG1 ARG2 ... ARGN]
 
 Where:
-* `-e`, `--env` `LIST` - Override environment variables. Comma separated
-  key=value pairs of environment variables to override in the existing
-  environment.
+* `-e`, `--env` `ENV` - Override environment variable from given name=value
+  pair. Can be specified multiple times to set multiple environment variables.
 * `-u`, `--user` `USER` - The username the process will setuid before executing
   COMMAND
 * `-g`, `--group` `GROUP` - The group name the process will setgid before

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repo](https://github.com/snoyberg/docker-testing#readme).
 
 ### Usage
 
-> pid1 [-e|--env ENV] [-u|--user USER] [-g|--group GROUP] [-w|--workdir DIR] COMMAND [ARG1 ARG2 ... ARGN]
+> pid1 [-e|--env ENV] [-u|--user USER] [-g|--group GROUP] [-w|--workdir DIR] [-t|--timeout TIMEOUT] COMMAND [ARG1 ARG2 ... ARGN]
 
 Where:
 * `-e`, `--env` `ENV` - Override environment variable from given name=value
@@ -32,6 +32,7 @@ Where:
 * `-g`, `--group` `GROUP` - The group name the process will setgid before
   executing COMMAND
 * `-w`, `--workdir` `DIR` - chdir to `DIR` before executing COMMAND
+* `-t`, `--timeout` `TIMEOUT` - timeout (in seconds) to wait for all child processes to exit
 
 The recommended use case for this executable is to embed it in a Docker image.
 Assuming you've placed it at `/sbin/pid1`, the two commonly recommended usages

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,7 +16,8 @@ options defaultEnv =
   [ Option ['e'] ["env"] (ReqArg (\opt opts -> setRunEnv (optEnvList (getRunEnv opts) opt) opts) "ENV") "override environment variable from given name=value pair. Can be specified multiple times to set multiple environment variables"
   , Option ['u'] ["user"] (ReqArg setRunUser "USER") "run command as user"
   , Option ['g'] ["group"] (ReqArg setRunGroup "GROUP") "run command as group"
-  , Option ['w'] ["workdir"] (ReqArg setRunWorkDir "DIR") "command working directory"]
+  , Option ['w'] ["workdir"] (ReqArg setRunWorkDir "DIR") "command working directory"
+  , Option ['t'] ["timeout"] (ReqArg (setRunExitTimeoutSec . read) "TIMEOUT") "timeout (in seconds) to wait for all child processes to exit" ]
   where optEnv env' kv =
           let kvp = fmap (drop 1) $ span (/= '=') kv in
             kvp:filter ((fst kvp /=) . fst) env'

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,6 @@ module Main (main) where
 -- entrypoint. It will handle reaping orphans and handling TERM and
 -- INT signals.
 
-import Data.List (foldl')
 import Data.Maybe (fromMaybe)
 import System.Process.PID1
 import System.Environment
@@ -14,18 +13,14 @@ import System.Exit (exitFailure)
 -- | `GetOpt` command line options
 options :: [(String, String)] -> [OptDescr (RunOptions -> RunOptions)]
 options defaultEnv =
-  [ Option ['e'] ["env"] (ReqArg (\opt opts -> setRunEnv (optEnvList (getRunEnv opts) opt) opts) "LIST") "set environment variables from list of comma separated name=value pairs. Can be specified multiple times"
+  [ Option ['e'] ["env"] (ReqArg (\opt opts -> setRunEnv (optEnvList (getRunEnv opts) opt) opts) "ENV") "override environment variable from given name=value pair. Can be specified multiple times to set multiple environment variables"
   , Option ['u'] ["user"] (ReqArg setRunUser "USER") "run command as user"
   , Option ['g'] ["group"] (ReqArg setRunGroup "GROUP") "run command as group"
   , Option ['w'] ["workdir"] (ReqArg setRunWorkDir "DIR") "command working directory"]
   where optEnv env' kv =
           let kvp = fmap (drop 1) $ span (/= '=') kv in
             kvp:filter ((fst kvp /=) . fst) env'
-        split [] = []
-        split s = case fmap (drop 1) $ span (/= ',') s of
-          ("", xs') -> split xs'
-          (x, xs') -> x:split xs'
-        optEnvList env' s = foldl' optEnv (fromMaybe defaultEnv env') $ split s
+        optEnvList = optEnv . fromMaybe defaultEnv
 
 main :: IO ()
 main = do

--- a/pid1.cabal
+++ b/pid1.cabal
@@ -1,5 +1,5 @@
 name:                pid1
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Do signal handling and orphan reaping for Unix PID1 init processes
 description:         Please see README.md or view Haddocks at <https://www.stackage.org/package/pid1>
 homepage:            https://github.com/fpco/pid1#readme


### PR DESCRIPTION
Sorry to submit this PR so soon after my last one, but I found two issues with my recent changes when using pid1 with a large Kafka cluster installation. 

One is the default timeout waiting for child process to exit cleanly. Kafka will cleanly shutdown when receiving the TERM signal, but it can take upwards of 30 seconds in our environment to flush it's log buffers and close connections. The default hard-coded timeout of 5 seconds is too short to allow for this to happen, forcing a log index rebuild on restart of kafka. With this PR, I added a `-t` option to specify the timeout in seconds for the process reaper to wait after sending SIGTERM/SIGINT to any child processes.

The other issue is with the `-e` option flag I added with last PR in dealing with ',' separated values. The issue is it's impossible to specify an environment variable that has ',' in the environment value. This came up when I tried to specify a zookeeper connection list, e.g. `-e ZOOKEEPER=zk1:2181,zk2:2181,zk3:2181` Rather than adding complexity with supporting escaping, I just removed the shorthand ',' list parsing, forcing one to use multiple `-e` options if multiple environment variables need to be set. 