### PR TITLE
Add static binary as part of releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'true'
-
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: 1.1.3
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -44,3 +46,9 @@ jobs:
             set -exuo pipefail
             curl -sSL https://get.haskellstack.org/ | sh -s - -f
             stack test --fast --no-terminal --stack-yaml=${{ matrix.stack-yaml }} --resolver=${{ matrix.resolver }}
+      - name: Static Binary check
+        shell: bash
+        run: |
+            set -exuo pipefail
+            just copy-static-pid1
+            just test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          tag_name: ${{ github.ref }}
-          release_name: pid1-${{ github.ref }}
-          body_path: ChangeLog.md
-          draft: false
-          prerelease: false
+          files: pid1
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: 1.1.3
+      - name: Static Binary Generation
+        shell: bash
+        run: |
+            set -exuo pipefail
+            just copy-static-pid1
+            just test
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM fpco/alpine-haskell-stack:9.2.5
+
+COPY . /app
+
+RUN apk add upx \
+    && env STACK_YAML=/app/stack.yaml stack --system-ghc install --local-bin-path /app --flag pid1:static \
+    && upx --best /app/pid1

--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+# List all recipies
+default:
+    just --list --unsorted
+
+# Build image
+build-image:
+    docker build --file Dockerfile . --tag pid1
+
+# Copy static binary from container
+copy-static-pid1: build-image
+    #!/usr/bin/env bash
+    set -euo pipefail
+    CID=$(docker create pid1)
+    docker cp ${CID}:/app/pid1 .
+    docker rm ${CID}
+    ls -lah pid1
+
+# Sanity test the binary
+test:
+    file ./pid1
+    ./pid1 -- ps


### PR DESCRIPTION
Summary of the changes:

- Test static binary generation in CI
- Create static binary as part of release asset. This is mostly to enable the workflow where you can add the pid1 static binary directly to an arbitrary Docker image: Tested here: https://github.com/psibi/pid1/releases/tag/v0.1.3.1
- Dockerfile which is used to create static binary.
